### PR TITLE
Skip questions

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -108,5 +108,6 @@
   "Leave your feedback and suggestions here": "Leave your feedback and suggestions here",
   "Send": "Send",
   "Back to my overview": "Back to my overview",
-  "We appreciate your feedback!": "We appreciate your feedback!"
+  "We appreciate your feedback!": "We appreciate your feedback!",
+   "Skip": "Skip"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -109,5 +109,5 @@
   "Send": "Send",
   "Back to my overview": "Back to my overview",
   "We appreciate your feedback!": "We appreciate your feedback!",
-   "Skip": "Skip"
+  "Skip": "Skip"
 }

--- a/lib/pages/questions/social_distancing.dart
+++ b/lib/pages/questions/social_distancing.dart
@@ -42,6 +42,29 @@ class _SocialDistancingState extends State<SocialDistancing> {
                   SizedBox(height: 20.0),
                   noButton(context, 'no', dayModel)
                 ]),
+                Expanded(
+                    child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: <Widget>[
+                    FlatButton(
+                      textColor: Colors.blueAccent,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: new BorderRadius.circular(18.0),
+                      ),
+                      color: Colors.transparent,
+                      child:
+                          Text(AppLocalizations.of(context).translate('Skip'),
+                              style: TextStyle(
+                                fontSize: 15.0,
+                                fontWeight: FontWeight.bold,
+                              )),
+                      onPressed: () {
+                        Navigator.pushNamed(context, 'summary');
+                      },
+                    )
+                  ],
+                ))
               ],
             ),
           ),
@@ -70,6 +93,7 @@ SizedBox yesButton(BuildContext context, String keyname, Day dayModel) {
         },
       ));
 }
+
 SizedBox noButton(BuildContext context, String keyname, Day dayModel) {
   return new SizedBox(
       width: 300.0,

--- a/lib/pages/questions/social_distancing.dart
+++ b/lib/pages/questions/social_distancing.dart
@@ -47,22 +47,24 @@ class _SocialDistancingState extends State<SocialDistancing> {
                   crossAxisAlignment: CrossAxisAlignment.end,
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: <Widget>[
-                    FlatButton(
-                      textColor: Colors.blueAccent,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: new BorderRadius.circular(18.0),
-                      ),
-                      color: Colors.transparent,
-                      child:
-                          Text(AppLocalizations.of(context).translate('Skip'),
+                    Padding(
+                        padding: const EdgeInsets.all(5.0),
+                        child: FlatButton(
+                          textColor: Colors.blueAccent,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: new BorderRadius.circular(18.0),
+                          ),
+                          color: Colors.transparent,
+                          child: Text(
+                              AppLocalizations.of(context).translate('Skip'),
                               style: TextStyle(
                                 fontSize: 15.0,
                                 fontWeight: FontWeight.bold,
                               )),
-                      onPressed: () {
-                        Navigator.pushNamed(context, 'summary');
-                      },
-                    )
+                          onPressed: () {
+                            Navigator.pushNamed(context, 'summary');
+                          },
+                        ))
                   ],
                 ))
               ],


### PR DESCRIPTION
Instead of a complete new screen, I added a small "Skip" button on the first question screen.

From my testing it seemed the app doesn't go back to the first question upon going to background and coming back! (So the other code doesn't seem necessary)