### PR TITLE
Minimize keyboard on iOS

### DIFF
--- a/lib/pages/questions/note.dart
+++ b/lib/pages/questions/note.dart
@@ -34,6 +34,7 @@ class _NoteForDayState extends State<NoteForDay> {
                       padding: const EdgeInsets.all(10.0),
                       child: TextField(
                           minLines: 10, maxLines: 15,
+                          textInputAction: TextInputAction.done,
                         decoration: InputDecoration(
                             border: InputBorder.none,
                             hintText: AppLocalizations.of(context)


### PR DESCRIPTION
On iOS devices, the keyboard would remain open on the Note page, even when clicking outside of the Text Input or navigating away from the screen to a previous question.

By changing the TextInputAction behavior to 'Done', the keyboard will be minimized instead of returning new lines. I found this was the easiest fix for minimizing the keyboard (rather than implementing a [GestureDetector](https://stackoverflow.com/questions/51652897/how-to-hide-soft-input-keyboard-on-flutter-after-clicking-outside-textfield-anyw) or [a separate Done button to minimize the keyboard](https://blog.usejournal.com/keyboard-done-button-ux-in-flutter-ios-app-3b29ad46bacc)).