### PR TITLE
Remove cloud_firestore package

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -64,13 +64,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.0"
-  cloud_firestore:
-    dependency: "direct main"
-    description:
-      name: cloud_firestore
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.12.11"
   collection:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,6 @@ dependencies:
   firebase_core: ^0.4.0+9
   firebase_auth: ^0.14.0+5
   firebase_database: ^3.0.7
-  cloud_firestore: ^0.12.9+5
   charts_flutter: ^0.9.0
   flutter_svg: ^0.17.3
   smooth_page_indicator: ^0.1.5


### PR DESCRIPTION
This package is deprecated and causes runtime issues in the latest version of flutter (v1.17.5)